### PR TITLE
Handle fails in GH workflow steps

### DIFF
--- a/.github/workflows/check-hooks-pr.yml
+++ b/.github/workflows/check-hooks-pr.yml
@@ -15,8 +15,16 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Check Git LFS for updates
+        id: check-git-lfs
         run: |
           ./scripts/update-from-git-lfs.sh
+      
+      - name: Exit gracefully
+        if: ${{ failure() }}
+        run: |
+          echo "Exiting gracefully after previous step failed." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY # this is a blank line
+          echo "${{ steps.check-git-lfs.outputs.stdout }}" >> $GITHUB_STEP_SUMMARY
 
       - name: Update the CHANGELOG.md
         run: |

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -21,8 +21,16 @@ jobs:
           make basic-tests
 
       - name: Check if .version has changed
+        id: check-version
         run: |
           ./scripts/check-version.sh
+      
+      - name: Exit gracefully
+        if: ${{ failure() }}
+        run: |
+          echo "Exiting gracefully after previous step failed." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY # this is a blank line
+          echo "${{ steps.check-version.outputs.stdout }}" >> $GITHUB_STEP_SUMMARY
       
       - name: Tag the commit with the new version
         run: |


### PR DESCRIPTION
When specific steps fail we want the
action to not show as failed.
Examples:
- the .version has not changed
- there are no updates from git-lfs

We also added the stdout of the failed steps
to the GITHUB_STEP_SUMMARY.